### PR TITLE
Add more flexibility: TSV, single space delimiting, more time formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__
 .idea
 *.egg-info
+build
+dist

--- a/taetitool/util.py
+++ b/taetitool/util.py
@@ -83,9 +83,13 @@ def load_issue_data(issue_title_file_path, project_data_file_path,
 
 def read_issue_titles(path):
     issue_titles = {}
+    delimiter = ','
+
+    if path.endswith('.tsv'):
+        delimiter = '\t'
 
     with open(path, 'r') as file:
-        csv_file = csv.reader(file, delimiter=',')
+        csv_file = csv.reader(file, delimiter=delimiter)
         for line in csv_file:
             try:
                 issue_id = line[0]
@@ -102,9 +106,13 @@ def read_issue_titles(path):
 
 def read_project_data(path):
     project_data = {}
+    delimiter = ','
+
+    if path.endswith('.tsv'):
+        delimiter = '\t'
 
     with (open(path, 'r') as file):
-        csv_file = csv.reader(file, delimiter=',')
+        csv_file = csv.reader(file, delimiter=delimiter)
         for line in csv_file:
             try:
                 issue_id = line[0]

--- a/taetitool/util.py
+++ b/taetitool/util.py
@@ -33,7 +33,12 @@ def parse_date(path):
 
 
 def parse_time(time_str):
-    return datetime.strptime(time_str, '%H:%M')
+    if re.match('\\d{3,4}', time_str):
+        if len(time_str) == 3:
+            time_str = '0' + time_str
+        return datetime.strptime(time_str, '%H%M')
+    else:
+        return datetime.strptime(time_str, '%H:%M')
 
 
 def format_time(time_obj):

--- a/taetitool/util.py
+++ b/taetitool/util.py
@@ -166,8 +166,8 @@ def read_taeti_data(path):
     with open(path, 'r') as file:
         for i, line in enumerate(file):
             if len(line.strip()):
-                # split by two or more whitespace characters
-                col = re.split('\\s\\s+', line)
+                # split by one or more whitespace characters
+                col = re.split('\\s+', line.strip(), maxsplit=2)
                 if len(col) != 3:
                     raise Exception(f'Corrupt entry in line {i + 1}: "{line}"')
                 time_start, time_end, description = col

--- a/tests/files/20240216-valid.taeti
+++ b/tests/files/20240216-valid.taeti
@@ -1,0 +1,33 @@
+715 0745 #9987
+745 755 #1123 Implementation
+0755 805 Debug transfer speed
+0805 830 Private
+830 855 #1123 Refactoring
+0900 0915 Private
+915 925 Private: prayer
+925 935 Orga
+935 945 Private: prayer
+945 1000 Private
+1000 1020 Daily
+1020 1025 #3123 Meeting
+1025 1030 #3987 Setup
+1035 1050 Reporting
+1055 1105 #5123 Concept
+1105 1125 #5124 Concept
+1125 1135 #5123 Concept
+1135 1145 #5223 Implementation feature X
+1145 1150 #5123 Concept
+1150 1155 #5223 Refactor feature X
+1155 1205 Orga: answer emails
+1205 1215 #5224 Implementation
+1215 1225 Orga
+1225 1245 Update Taetis
+1245 1345 Lunch break
+1345 1415 #7123
+1415 1430 #7987
+1430 1500 #9123 Implementation
+1500 1520 #9987 Refactoring
+1530 1600 Product Management Round Table
+1600 1610 #1987
+1610 1630 #1987 Testing
+1630 1645 #1987 Documentation

--- a/tests/files/issue_titles.tsv
+++ b/tests/files/issue_titles.tsv
@@ -1,0 +1,8 @@
+1123	Data import for CSV
+3123	Support case 221
+3987	Configuration of another feature for tenant X
+5223	Implementation of Module A
+5224	Implementation of Module B
+7123	Support case 223
+7124	Support case 224
+7987	Support case 227

--- a/tests/files/project_data.tsv
+++ b/tests/files/project_data.tsv
@@ -1,0 +1,10 @@
+1123	ACME	Customizing	Data import
+1987	ACME	Customizing	Testing
+3123	PI Fan AG	Remote Support
+3987	PI Fan AG	Configuration
+5123	Fancy Project	AP02-01 Concept Module A
+5124	Fancy Project	AP02-01 Concept Module B
+5223	Fancy Project	AP02-02 Implementation Module A
+5224	Fancy Project	AP02-02 Implementation Module B
+7123	Support
+7987	Support

--- a/tests/test_load_issue_data.py
+++ b/tests/test_load_issue_data.py
@@ -33,6 +33,35 @@ class TestAssignmentRuleParsing(unittest.TestCase):
         self.assertEqual(issue_data['5123'].description, '')
         self.assertEqual(issue_data['5123'].title, None)
 
+    def test_load_issue_data_tsv(self):
+        issue_data = util.load_issue_data('files/issue_titles.tsv',
+                                          'files/project_data.tsv',
+                                          'Default project',
+                                          'Default task')
+
+        expected_issue_ids = ['1123', '1987', '3123', '3987', '5123', '5124',
+                              '5223', '5224', '7123', '7987', '7124']
+
+        self.assertListEqual(list(issue_data.keys()), expected_issue_ids)
+
+        # issue with both issue title and project data
+        self.assertEqual(issue_data['1123'].project, 'ACME')
+        self.assertEqual(issue_data['1123'].task, 'Customizing')
+        self.assertEqual(issue_data['1123'].description, 'Data import')
+        self.assertEqual(issue_data['1123'].title, 'Data import for CSV')
+
+        # issue with issue title but no project data
+        self.assertEqual(issue_data['7123'].project, 'Support')
+        self.assertEqual(issue_data['7123'].task, '')
+        self.assertEqual(issue_data['7123'].description, '')
+        self.assertEqual(issue_data['7123'].title, 'Support case 223')
+
+        # issue with project data but no issue title
+        self.assertEqual(issue_data['5123'].project, 'Fancy Project')
+        self.assertEqual(issue_data['5123'].task, 'AP02-01 Concept Module A')
+        self.assertEqual(issue_data['5123'].description, '')
+        self.assertEqual(issue_data['5123'].title, None)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_taeti_aggregator.py
+++ b/tests/test_taeti_aggregator.py
@@ -215,6 +215,214 @@ class TestTaetiAggretator(unittest.TestCase):
         self.assertEqual(taeti_aggretaion_json['day_total_time'], 34200)
         self.assertDictEqual(taeti_aggretaion_json['taetis'], expected_taetis)
 
+    def test_valid_file_single_space_format(self):
+        taeti_file_path = 'files/20240216-valid.taeti'
+
+        default_issue = Issue(None, None, 'Default project', 'Default task')
+
+        issue_data = DefaultKeyDict(default_issue, {
+            '1123': Issue(1123, 'Data import for CSV', 'ACME', 'Customizing',
+                          'Data import'),
+            '1987': Issue(1987, 'None', 'ACME', 'Customizing', 'Testing'),
+            '3123': Issue(3123, 'Support case 221', 'PI Fan AG',
+                          'Remote Support', ''),
+            '3987': Issue(3987, 'Configuration of another feature for tenant X',
+                          'PI Fan AG', 'Configuration', ''),
+            '5123': Issue(5123, 'None', 'Fancy Project',
+                          'AP02-01 Concept Module A', ''),
+            '5124': Issue(5124, 'None', 'Fancy Project',
+                          'AP02-01 Concept Module B', ''),
+            '5223': Issue(5223, 'Implementation of Module A', 'Fancy Project',
+                          'AP02-02 Implementation Module A', ''),
+            '5224': Issue(5224, 'Implementation of Module B', 'Fancy Project',
+                          'AP02-02 Implementation Module B', ''),
+            '7123': Issue(7123, 'Support case 223', 'Support', '', ''),
+            '7987': Issue(7987, 'Support case 227', 'Support', '', ''),
+            '7124': Issue(7124, 'Support case 224', 'Default project',
+                          'Default task', 'None')
+        })
+
+        assignment_rules = [
+            {
+                'name': 'break',
+                'attribute': 'description',
+                'pattern': 'Break|^Private',
+                'project': 'Break',
+                'task': 'Break'
+            },
+            {
+                'name': 'meeting',
+                'attribute': 'description',
+                'pattern': 'Daily|Weekly|Sprint Retrospective|Product Management Round Table',
+                'project': 'Internal tasks',
+                'task': 'Meeting'
+            },
+            {
+                'name': 'support',
+                'attribute': 'project',
+                'pattern': 'Support',
+                'project': 'External tasks',
+                'task': 'Support'
+            }
+        ]
+
+        expected_taetis = {
+            "Default project": {
+                "time": 4800,
+                "Default task": {
+                    "time": 4800,
+                    "None": {
+                        "time": 4800,
+                        "9987": {
+                            "time": 3000
+                        },
+                        "9123": {
+                            "time": 1800
+                        }
+                    }
+                }
+            },
+            "ACME": {
+                "time": 4800,
+                "Customizing": {
+                    "time": 4800,
+                    "Data import": {
+                        "time": 2100,
+                        "1123": {
+                            "time": 2100
+                        }
+                    },
+                    "Testing": {
+                        "time": 2700,
+                        "1987": {
+                            "time": 2700
+                        }
+                    }
+                }
+            },
+            "None": {
+                "time": 8100,
+                "None": {
+                    "time": 8100,
+                    "None": {
+                        "time": 8100,
+                        "None": {
+                            "time": 8100
+                        }
+                    }
+                }
+            },
+            "Break": {
+                "time": 4500,
+                "Break": {
+                    "time": 4500,
+                    "None": {
+                        "time": 4500,
+                        "None": {
+                            "time": 4500
+                        }
+                    }
+                }
+            },
+            "Internal tasks": {
+                "time": 3000,
+                "Meeting": {
+                    "time": 3000,
+                    "None": {
+                        "time": 3000,
+                        "None": {
+                            "time": 3000
+                        }
+                    }
+                }
+            },
+            "PI Fan AG": {
+                "time": 600,
+                "Remote Support": {
+                    "time": 300,
+                    "None": {
+                        "time": 300,
+                        "3123": {
+                            "time": 300
+                        }
+                    }
+                },
+                "Configuration": {
+                    "time": 300,
+                    "None": {
+                        "time": 300,
+                        "3987": {
+                            "time": 300
+                        }
+                    }
+                }
+            },
+            "Fancy Project": {
+                "time": 4200,
+                "AP02-01 Concept Module A": {
+                    "time": 1500,
+                    "None": {
+                        "time": 1500,
+                        "5123": {
+                            "time": 1500
+                        }
+                    }
+                },
+                "AP02-01 Concept Module B": {
+                    "time": 1200,
+                    "None": {
+                        "time": 1200,
+                        "5124": {
+                            "time": 1200
+                        }
+                    }
+                },
+                "AP02-02 Implementation Module A": {
+                    "time": 900,
+                    "None": {
+                        "time": 900,
+                        "5223": {
+                            "time": 900
+                        }
+                    }
+                },
+                "AP02-02 Implementation Module B": {
+                    "time": 600,
+                    "None": {
+                        "time": 600,
+                        "5224": {
+                            "time": 600
+                        }
+                    }
+                }
+            },
+            "External tasks": {
+                "time": 2700,
+                "Support": {
+                    "time": 2700,
+                    "None": {
+                        "time": 2700,
+                        "7123": {
+                            "time": 1800
+                        },
+                        "7987": {
+                            "time": 900
+                        }
+                    }
+                }
+            }
+        }
+
+        taeti_aggregator = TaetiAggregator(issue_data, assignment_rules)
+        taeti_aggretation = taeti_aggregator.process(taeti_file_path)
+
+        taeti_aggretaion_json = taeti_aggretation.to_json()
+
+        self.maxDiff = None
+
+        self.assertEqual(taeti_aggretaion_json['date'], 'Friday, 16.02.2024')
+        self.assertEqual(taeti_aggretaion_json['day_total_time'], 34200)
+        self.assertDictEqual(taeti_aggretaion_json['taetis'], expected_taetis)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Adjustments

- Tab separated files (TSV) can be used besides the CSV files
- Add flexibility in the time format (`900` now also possible besides `09:00`)
- Add single space delimiting for taeti files
  - make line parsing more robust with `maxsplit` option
- Add tests for everything that was added/updated 😎 